### PR TITLE
Example in Version ordering doc does not match implementation

### DIFF
--- a/versions/shared/src/test/scala/coursier/version/VersionTests.scala
+++ b/versions/shared/src/test/scala/coursier/version/VersionTests.scala
@@ -415,6 +415,12 @@ object VersionTests extends TestSuite {
       val expectedItems = Seq(Version.Number(1), Version.Max, Version.Number(0), Version.Tag("alpha"))
       assert(items == expectedItems)
     }
+
+
+    "orderingDocExamples" - {
+      assert(compare("1.0.1", "1.0.1e" ) < 0)
+      assert(compare("1.0.1.0", "1.0.1e" ) < 0)
+    }
   }
 
 }


### PR DESCRIPTION
The [documentation for Version ordering](https://get-coursier.io/docs/other-version-handling.html#ordering) contains this example:

> 1.0.1 or 1.0.1.0 goes before 1.0.1e (literal e goes after empty / zero items)

But this does not match the implementation which is demonstrated by the
added test:
```
utest.AssertionError: assert(compare("1.0.1", "1.0.1e" ) < 0)
```

1.0.1 and 1.0.1.0 are both actually greater than 1.0.1e:
```scala
scala> Version("1.0.1").compare(Version("1.0.1e"))
val res1: Int = 1

scala> Version("1.0.1.0").compare(Version("1.0.1e"))
val res2: Int = 1
```