### PR TITLE
Fix `minimumCompatibleVersion` in semver, packver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           ${{ runner.OS }}-coursier-cache-${{ hashFiles('**/*.sbt') }}-
           ${{ runner.OS }}-coursier-cache-
 
-    - uses: olafurpg/setup-scala@v7
+    - uses: olafurpg/setup-scala@v10
       with:
         java-version: adopt@1.8.0-232
 
@@ -51,9 +51,9 @@ jobs:
             ${{ runner.OS }}-coursier-cache-${{ hashFiles('**/*.sbt') }}-
             ${{ runner.OS }}-coursier-cache-
 
-      - uses: olafurpg/setup-scala@v7
+      - uses: olafurpg/setup-scala@v10
 
-      - uses: olafurpg/setup-gpg@v2
+      - uses: olafurpg/setup-gpg@v3
 
       - name: Release
         run: csbt ci-release

--- a/versions/shared/src/main/scala/coursier/version/VersionCompatibility.scala
+++ b/versions/shared/src/main/scala/coursier/version/VersionCompatibility.scala
@@ -98,7 +98,7 @@ object VersionCompatibility {
         .filter(_.forall(_.isNumber))
         .map(_.collect { case n: Version.Numeric => n })
         .map(items => items.map(_.repr).mkString("."))
-        .filter(s => Version(s).compareTo(v) < 0)
+        .filter(s => Version(s).compareTo(v) <= 0)
       candidateOpt.getOrElse(version)
     }
   }
@@ -131,7 +131,7 @@ object VersionCompatibility {
         .filter(items => items.nonEmpty && items.forall(_.isNumber) && items.forall(!_.isEmpty))
         .map(_.collect { case n: Version.Numeric => n })
         .map(items => items.map(_.repr).mkString("."))
-        .filter(s => Version(s).compareTo(v) < 0)
+        .filter(s => Version(s).compareTo(v) <= 0)
       candidateOpt.getOrElse(version)
     }
   }
@@ -152,7 +152,7 @@ object VersionCompatibility {
         .filter(_.forall(_.isNumber))
         .map(_.collect { case n: Version.Numeric => n })
         .map(items => items.map(_.repr).mkString("."))
-        .filter(s => Version(s).compareTo(v) < 0)
+        .filter(s => Version(s).compareTo(v) <= 0)
       candidateOpt.getOrElse(version)
     }
   }

--- a/versions/shared/src/test/scala/coursier/version/VersionCompatibilityTests.scala
+++ b/versions/shared/src/test/scala/coursier/version/VersionCompatibilityTests.scala
@@ -24,6 +24,7 @@ object VersionCompatibilityTests extends TestSuite {
       implicit val compat = VersionCompatibility.EarlySemVer
 
       test - compatible("1.1.0", "1.2.3")
+      test - compatible("1.0.0", "1.2.3")
       test - compatible("1.1.0", "1.2.3-RC1")
       test - incompatible("1.2.3-RC1", "1.2.3-RC2")
 
@@ -35,6 +36,9 @@ object VersionCompatibilityTests extends TestSuite {
 
       test - minimumCompatible("0.0.1", "0.0")
       test - minimumCompatible("0.1.2", "0.1")
+      test - minimumCompatible("1.0.0", "1")
+      test - minimumCompatible("0.0.0", "0.0")
+      test - minimumCompatible("0.1.0", "0.1")
     }
 
     "semverspec" - {
@@ -42,6 +46,7 @@ object VersionCompatibilityTests extends TestSuite {
       implicit val compat = VersionCompatibility.SemVerSpec
 
       test - compatible("1.1.0", "1.2.3")
+      test - compatible("1.0.0", "1.2.3")
       test - compatible("1.1.0", "1.2.3-RC1")
       test - incompatible("1.2.3-RC1", "1.2.3-RC2")
 
@@ -53,6 +58,9 @@ object VersionCompatibilityTests extends TestSuite {
 
       test - minimumCompatible("0.0.1", "0.0.1")
       test - minimumCompatible("0.1.2", "0.1.2")
+      test - minimumCompatible("1.0.0", "1")
+      test - minimumCompatible("0.0.0", "0.0.0")
+      test - minimumCompatible("0.1.0", "0.1.0")
     }
 
     "package versioning" - {
@@ -60,7 +68,9 @@ object VersionCompatibilityTests extends TestSuite {
       implicit val compat = VersionCompatibility.PackVer
 
       test - incompatible("1.1.0", "1.2.3")
+      test - incompatible("1.0.0", "1.2.3")
       test - incompatible("1.1.0", "1.2.3-RC1")
+      test - compatible("1.0.0", "1.0.1")
       test - compatible("0.1.0", "0.1.0+foo")
 
       test - minimumCompatible("1.0.1", "1.0")
@@ -68,6 +78,7 @@ object VersionCompatibilityTests extends TestSuite {
 
       test - minimumCompatible("0.0.1", "0.0")
       test - minimumCompatible("0.1.2", "0.1")
+      test - minimumCompatible("1.0.0", "1.0")
     }
 
     "all" - {


### PR DESCRIPTION
Previously, `EarlySemVer`, `SemVerSpec` and `PackVer` would return
unexpected results when `minimumCompatibleVersion` was called with a
version number such as `1.0.0` (they would all return `1.0.0`).

This commit fixes it so that they return, respectively, `1`, `1` and
`1.0`.