### PR TITLE
Fix Equality To Be Consistent With Compare In Version

### DIFF
--- a/versions/shared/src/test/scala/coursier/version/VersionTests.scala
+++ b/versions/shared/src/test/scala/coursier/version/VersionTests.scala
@@ -8,6 +8,17 @@ object VersionTests extends TestSuite {
   def compare(first: String, second: String) =
     Version(first).compare(Version(second))
 
+  def compareEqualsConsistent(first: String, second: String): Boolean = {
+    val firstV: Version = Version(first)
+    val secondV: Version = Version(second)
+
+    if (firstV.compare(secondV) == 0) {
+      firstV == secondV && firstV.hashCode == secondV.hashCode
+    } else {
+      firstV != secondV
+    }
+  }
+
   def increasing(versions: String*): Boolean =
     versions.iterator.sliding(2).withPartial(false).forall{case Seq(a, b) => compare(a, b) < 0 }
 
@@ -86,6 +97,12 @@ object VersionTests extends TestSuite {
       assert(compare("0", "" ) == 0)
     }
 
+    "compareIsConsistentWithEquals" - {
+      assert(compareEqualsConsistent("1.0.0", "1.0.0"))
+      assert(compareEqualsConsistent("1.0.0", "1.0.0.0"))
+      assert(compareEqualsConsistent("1.0.0", "1"))
+      assert(compareEqualsConsistent("1.0.0", "2.0.0"))
+    }
 
     "numericOrdering" - {
       assert(compare("2", "10" ) < 0)


### PR DESCRIPTION
This commit fixes the `def equals` method to be consistent with compare in `Version`. The reason for the inconsistency was that `data-class` was generating an `equals` method based off the `repr` (e.g. `this.repr == that.repr`), however `compare` is encoded to determine logical equality of a binary API with respect to SemVer (sort of). That is to say, `compare` compares two values by padding them to equal numeric length and then dropping the metadata value.

Unfortunately, we can not simply override the `equals` method _and_ use the `@data` annotation (attempting to do so causes a compilation error). Thus this commit re-implements the methods from `@data`, but _only_ for `Version`. Data types which do not implement `Ordered` do not need this special case treatment.

The implementation of `compare` likely bares some further discussion. It creates a situation where the `hashCode` and equality are unexpected for users cases other than comparing binary APIs.

For example, if I want to create a `Set` of `Version` values, this is likely unexpected behavior.

```scala
scala> Set(Version("1.0.0"), Version("1.0"), Version("1.0.0+SOME_META"))
val res0: scala.collection.immutable.Set[coursier.version.Version] = Set(Version(1.0.0))
```

Though there is no other way to implement `equals` and `hashCode` such that it is consistent with the current implementation of `compare`, however changing `compare` may likely have some unintended consequences as well.