### PR TITLE
Optimize merge/compare for duplicates

### DIFF
--- a/versions/shared/src/coursier/version/Version.scala
+++ b/versions/shared/src/coursier/version/Version.scala
@@ -19,7 +19,10 @@ import scala.annotation.tailrec
       items0 = Version.items(repr)
     items0
   }
-  def compare(other: Version) = Version.listCompare(items, other.items)
+  def compare(other: Version) = {
+    if (repr == other.repr) 0 // fast path
+    else Version.listCompare(items, other.items)
+  }
   def isEmpty = items.forall(_.isEmpty)
 
   lazy val isStable: Boolean =

--- a/versions/shared/src/coursier/version/VersionConstraint.scala
+++ b/versions/shared/src/coursier/version/VersionConstraint.scala
@@ -69,7 +69,9 @@ object VersionConstraint {
         None
       )
 
-  def merge(constraints: VersionConstraint*): Option[VersionConstraint] =
+  def merge(constraints0: VersionConstraint*): Option[VersionConstraint] = {
+    // Initial pass to filter exact duplicates
+    val constraints = constraints0.distinct
     if (constraints.isEmpty) Some(empty)
     else if (constraints.lengthCompare(1) == 0) Some(constraints.head).filter(_.isValid)
     else {
@@ -104,6 +106,7 @@ object VersionConstraint {
 
       constraintOpt.filter(_.isValid)
     }
+  }
 
   // 1. sort constraints in ascending order.
   // 2. from the right, merge them two-by-two with the merge method above


### PR DESCRIPTION
Even after my recent perf. improvement to Version.compare,
it remains a hotspot in coursier profiles.

I looked at the data being processed which revealed the
opportunity for fast paths for equivalent versions, and for
a `.distinct` dedup pass prior to merging.